### PR TITLE
Add service calendar plus button

### DIFF
--- a/jeecgboot-vue3/src/enums/careSysEnum.ts
+++ b/jeecgboot-vue3/src/enums/careSysEnum.ts
@@ -1,0 +1,49 @@
+export const genderOptions = [
+  { label: '男', value: 'M' },
+  { label: '女', value: 'F' },
+];
+
+export const employmentTypeOptions = [
+  { label: '全职', value: 'full_time' },
+  { label: '兼职', value: 'part_time' },
+  { label: '合同', value: 'contract' },
+];
+
+export const eventTypeOptions = [
+  { label: '访视', value: 'visit' },
+  { label: '培训', value: 'training' },
+  { label: '检修', value: 'maintenance' },
+];
+
+export const announceLevelOptions = [
+  { label: '系统', value: 'system' },
+  { label: '公司', value: 'company' },
+  { label: '事务所', value: 'office' },
+];
+
+export const repeatTypeOptions = [
+  { label: '日', value: 'day' },
+  { label: '周', value: 'week' },
+];
+
+export const statusOptions = [
+  { label: '在住', value: 'active' },
+  { label: '停用', value: 'disabled' },
+  { label: '逝世', value: 'deceased' },
+];
+
+export const reportTypeOptions = [
+  { label: '跌倒', value: 'fall' },
+  { label: '其他', value: 'other' },
+];
+
+export const feedbackSourceOptions = [
+  { label: '家属', value: 'family' },
+  { label: '员工', value: 'employee' },
+];
+
+export const residenceTypeOptions = [
+  { label: '独居', value: 'alone' },
+  { label: '与家人同住', value: 'family' },
+  { label: '机构', value: 'facility' },
+];

--- a/jeecgboot-vue3/src/views/caresys/CsServiceCalendar.vue
+++ b/jeecgboot-vue3/src/views/caresys/CsServiceCalendar.vue
@@ -17,6 +17,7 @@
                 v-for="item in getDateEvents(date)"
                 :key="item.id"
                 :class="item.type"
+                @click="handleView(item)"
               >
                 <a-tooltip :title="item.residentName + ' - ' + item.title">
                   <span>{{ item.title }}</span>
@@ -53,6 +54,7 @@
                     v-for="item in getResidentDateEvents(res.id, day)"
                     :key="item.id"
                     :class="item.type"
+                    @click="handleView(item)"
                   >
                     <a-tooltip :title="item.title">
                       <span>{{ item.title }}</span>
@@ -70,6 +72,7 @@
       </table>
     </div>
     <CsCareRecordModal ref="recordModal" @success="loadEvents" />
+    <CsCarePlanModal ref="planModal" @success="loadEvents" />
   </div>
 </template>
 
@@ -80,6 +83,7 @@ import { list as listPlan } from './CsCarePlan.api';
 import { list as listRecord } from './CsCareRecord.api';
 import { list as listResident } from './CsResident.api';
 import CsCareRecordModal from './components/CsCareRecordModal.vue';
+import CsCarePlanModal from './components/CsCarePlanModal.vue';
 import { PlusOutlined } from '@ant-design/icons-vue';
 
 interface CalendarEvent {
@@ -89,12 +93,14 @@ interface CalendarEvent {
   residentName: string;
   type: 'plan' | 'record';
   title: string;
+  raw: any;
 }
 
 const current = ref(dayjs());
 const events = ref<CalendarEvent[]>([]);
 const residents = ref<any[]>([]);
 const recordModal = ref();
+const planModal = ref();
 const viewMode = ref<'calendar' | 'resident'>('calendar');
 
 const monthDays = computed(() => {
@@ -156,6 +162,7 @@ async function loadEvents() {
         residentName: getResidentName(p.residentId),
         type: 'plan',
         title: p.serviceItems || '计划',
+        raw: p,
       }))
     );
   }
@@ -169,6 +176,7 @@ async function loadEvents() {
         residentName: getResidentName(r.residentId),
         type: 'record',
         title: r.serviceContent || '记录',
+        raw: r,
       }))
     );
   }
@@ -182,6 +190,16 @@ function getDateEvents(date: dayjs.Dayjs) {
 function getResidentDateEvents(residentId: string, date: dayjs.Dayjs) {
   const d = date.format('YYYY-MM-DD');
   return events.value.filter((e) => e.date === d && e.residentId === residentId);
+}
+
+function handleView(item: CalendarEvent) {
+  if (item.type === 'record') {
+    recordModal.value.disableSubmit = true;
+    recordModal.value.edit(item.raw);
+  } else {
+    planModal.value.disableSubmit = true;
+    planModal.value.edit(item.raw);
+  }
 }
 
 function handleAdd(date: dayjs.Dayjs) {

--- a/jeecgboot-vue3/src/views/caresys/CsServiceCalendar.vue
+++ b/jeecgboot-vue3/src/views/caresys/CsServiceCalendar.vue
@@ -225,6 +225,8 @@ function getResidentName(id: string) {
   margin: 0;
   padding: 0;
   list-style: none;
+  max-height: calc(100% - 16px);
+  overflow-y: auto;
 }
 .event-item {
   font-size: 12px;
@@ -242,6 +244,7 @@ function getResidentName(id: string) {
 
 .cell-wrapper {
   position: relative;
+  min-height: 80px;
 }
 
 .add-icon {

--- a/jeecgboot-vue3/src/views/caresys/CsServiceCalendar.vue
+++ b/jeecgboot-vue3/src/views/caresys/CsServiceCalendar.vue
@@ -151,11 +151,11 @@ async function loadEvents() {
     events.value.push(
       ...planRes.result.records.map((p: any) => ({
         id: p.id,
-        date: dayjs(p.planDate || p.plan_date).format('YYYY-MM-DD'),
-        residentId: p.residentId || p.resident_id,
-        residentName: getResidentName(p.residentId || p.resident_id),
+        date: dayjs(p.planDate).format('YYYY-MM-DD'),
+        residentId: p.residentId,
+        residentName: getResidentName(p.residentId),
         type: 'plan',
-        title: p.serviceItems || p.service_items || '计划',
+        title: p.serviceItems || '计划',
       }))
     );
   }
@@ -164,11 +164,11 @@ async function loadEvents() {
     events.value.push(
       ...recordRes.result.records.map((r: any) => ({
         id: r.id,
-        date: dayjs(r.recordTime || r.record_time).format('YYYY-MM-DD'),
-        residentId: r.residentId || r.resident_id,
-        residentName: getResidentName(r.residentId || r.resident_id),
+        date: dayjs(r.recordTime).format('YYYY-MM-DD'),
+        residentId: r.residentId,
+        residentName: getResidentName(r.residentId),
         type: 'record',
-        title: r.serviceContent || r.service_content || '记录',
+        title: r.serviceContent || '记录',
       }))
     );
   }

--- a/jeecgboot-vue3/src/views/caresys/CsServiceCalendar.vue
+++ b/jeecgboot-vue3/src/views/caresys/CsServiceCalendar.vue
@@ -74,7 +74,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted, computed, watch } from 'vue';
 import dayjs from 'dayjs';
 import { list as listPlan } from './CsCarePlan.api';
 import { list as listRecord } from './CsCareRecord.api';
@@ -107,6 +107,13 @@ const monthDays = computed(() => {
   return days;
 });
 
+watch(
+  () => current.value.format('YYYY-MM'),
+  () => {
+    loadEvents();
+  }
+);
+
 onMounted(() => {
   loadAll();
 });
@@ -122,9 +129,21 @@ async function loadResidents() {
 }
 
 async function loadEvents() {
+  const monthStart = current.value.startOf('month').format('YYYY-MM-DD 00:00:00');
+  const monthEnd = current.value.endOf('month').format('YYYY-MM-DD 23:59:59');
   const [planRes, recordRes] = await Promise.all([
-    listPlan({ pageNo: 1, pageSize: 999 }),
-    listRecord({ pageNo: 1, pageSize: 999 }),
+    listPlan({
+      pageNo: 1,
+      pageSize: 999,
+      planDate_begin: monthStart,
+      planDate_end: monthEnd,
+    }),
+    listRecord({
+      pageNo: 1,
+      pageSize: 999,
+      recordTime_begin: monthStart,
+      recordTime_end: monthEnd,
+    }),
   ]);
   events.value = [];
 
@@ -132,11 +151,11 @@ async function loadEvents() {
     events.value.push(
       ...planRes.result.records.map((p: any) => ({
         id: p.id,
-        date: dayjs(p.planDate).format('YYYY-MM-DD'),
-        residentId: p.residentId,
-        residentName: getResidentName(p.residentId),
+        date: dayjs(p.planDate || p.plan_date).format('YYYY-MM-DD'),
+        residentId: p.residentId || p.resident_id,
+        residentName: getResidentName(p.residentId || p.resident_id),
         type: 'plan',
-        title: p.serviceItems || '计划',
+        title: p.serviceItems || p.service_items || '计划',
       }))
     );
   }
@@ -145,11 +164,11 @@ async function loadEvents() {
     events.value.push(
       ...recordRes.result.records.map((r: any) => ({
         id: r.id,
-        date: dayjs(r.recordTime).format('YYYY-MM-DD'),
-        residentId: r.residentId,
-        residentName: getResidentName(r.residentId),
+        date: dayjs(r.recordTime || r.record_time).format('YYYY-MM-DD'),
+        residentId: r.residentId || r.resident_id,
+        residentName: getResidentName(r.residentId || r.resident_id),
         type: 'record',
-        title: r.serviceContent || '记录',
+        title: r.serviceContent || r.service_content || '记录',
       }))
     );
   }

--- a/jeecgboot-vue3/src/views/caresys/CsServiceCalendar.vue
+++ b/jeecgboot-vue3/src/views/caresys/CsServiceCalendar.vue
@@ -1,0 +1,250 @@
+<template>
+  <div class="p-2">
+    <div class="mb-2">
+      <a-radio-group v-model:value="viewMode">
+        <a-radio-button value="calendar">日历视图</a-radio-button>
+        <a-radio-button value="resident">利用者视图</a-radio-button>
+      </a-radio-group>
+    </div>
+
+    <div v-show="viewMode === 'calendar'">
+      <a-calendar v-model:value="current" :fullscreen="true">
+        <template #dateCellRender="{ current: date }">
+          <div class="cell-wrapper">
+            <div class="event-list">
+              <div
+                class="event-item"
+                v-for="item in getDateEvents(date)"
+                :key="item.id"
+                :class="item.type"
+              >
+                <a-tooltip :title="item.residentName + ' - ' + item.title">
+                  <span>{{ item.title }}</span>
+                </a-tooltip>
+              </div>
+            </div>
+            <PlusOutlined class="add-icon" @click.stop="handleAdd(date)" />
+          </div>
+        </template>
+      </a-calendar>
+    </div>
+
+    <div v-show="viewMode === 'resident'" class="resident-wrapper">
+      <table class="resident-table">
+        <thead>
+          <tr>
+            <th class="resident-name-col">利用者</th>
+            <th v-for="day in monthDays" :key="day.format('YYYY-MM-DD')">
+              {{ day.format('MM/DD') }}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="res in residents" :key="res.id">
+            <td class="resident-name">{{ res.name }}</td>
+            <td
+              v-for="day in monthDays"
+              :key="res.id + '-' + day.format('YYYY-MM-DD')"
+            >
+              <div class="cell-wrapper">
+                <div class="event-list">
+                  <div
+                    class="event-item"
+                    v-for="item in getResidentDateEvents(res.id, day)"
+                    :key="item.id"
+                    :class="item.type"
+                  >
+                    <a-tooltip :title="item.title">
+                      <span>{{ item.title }}</span>
+                    </a-tooltip>
+                  </div>
+                </div>
+                <PlusOutlined
+                  class="add-icon"
+                  @click.stop="handleAddForResident(res.id, day)"
+                />
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <CsCareRecordModal ref="recordModal" @success="loadEvents" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, onMounted, computed } from 'vue';
+import dayjs from 'dayjs';
+import { list as listPlan } from './CsCarePlan.api';
+import { list as listRecord } from './CsCareRecord.api';
+import { list as listResident } from './CsResident.api';
+import CsCareRecordModal from './components/CsCareRecordModal.vue';
+import { PlusOutlined } from '@ant-design/icons-vue';
+
+interface CalendarEvent {
+  id: string;
+  date: string;
+  residentId: string;
+  residentName: string;
+  type: 'plan' | 'record';
+  title: string;
+}
+
+const current = ref(dayjs());
+const events = ref<CalendarEvent[]>([]);
+const residents = ref<any[]>([]);
+const recordModal = ref();
+const viewMode = ref<'calendar' | 'resident'>('calendar');
+
+const monthDays = computed(() => {
+  const start = current.value.startOf('month');
+  const end = current.value.endOf('month');
+  const days: dayjs.Dayjs[] = [];
+  for (let d = start; d.isBefore(end) || d.isSame(end, 'day'); d = d.add(1, 'day')) {
+    days.push(d);
+  }
+  return days;
+});
+
+onMounted(() => {
+  loadAll();
+});
+
+async function loadAll() {
+  await loadResidents();
+  await loadEvents();
+}
+
+async function loadResidents() {
+  const res = await listResident({ pageNo: 1, pageSize: 999 });
+  residents.value = res?.result?.records || [];
+}
+
+async function loadEvents() {
+  const [planRes, recordRes] = await Promise.all([
+    listPlan({ pageNo: 1, pageSize: 999 }),
+    listRecord({ pageNo: 1, pageSize: 999 }),
+  ]);
+  events.value = [];
+
+  if (planRes?.result?.records) {
+    events.value.push(
+      ...planRes.result.records.map((p: any) => ({
+        id: p.id,
+        date: dayjs(p.planDate).format('YYYY-MM-DD'),
+        residentId: p.residentId,
+        residentName: getResidentName(p.residentId),
+        type: 'plan',
+        title: p.serviceItems || '计划',
+      }))
+    );
+  }
+
+  if (recordRes?.result?.records) {
+    events.value.push(
+      ...recordRes.result.records.map((r: any) => ({
+        id: r.id,
+        date: dayjs(r.recordTime).format('YYYY-MM-DD'),
+        residentId: r.residentId,
+        residentName: getResidentName(r.residentId),
+        type: 'record',
+        title: r.serviceContent || '记录',
+      }))
+    );
+  }
+}
+
+function getDateEvents(date: dayjs.Dayjs) {
+  const d = date.format('YYYY-MM-DD');
+  return events.value.filter((e) => e.date === d);
+}
+
+function getResidentDateEvents(residentId: string, date: dayjs.Dayjs) {
+  const d = date.format('YYYY-MM-DD');
+  return events.value.filter((e) => e.date === d && e.residentId === residentId);
+}
+
+function handleAdd(date: dayjs.Dayjs) {
+  const dt = date.format('YYYY-MM-DD 00:00:00');
+  recordModal.value.disableSubmit = false;
+  recordModal.value.edit({ recordTime: dt });
+}
+
+function handleAddForResident(residentId: string, date: dayjs.Dayjs) {
+  const dt = date.format('YYYY-MM-DD 00:00:00');
+  recordModal.value.disableSubmit = false;
+  recordModal.value.edit({ recordTime: dt, residentId });
+}
+
+function getResidentName(id: string) {
+  const r = residents.value.find((m) => m.id === id);
+  return r ? r.name : '';
+}
+</script>
+
+<style scoped>
+.event-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.event-item {
+  font-size: 12px;
+  margin-bottom: 2px;
+  padding: 2px 4px;
+  border-radius: 2px;
+  background-color: #f0f2f5;
+}
+.event-item.record {
+  background-color: #fde2e2;
+}
+.event-item.plan {
+  background-color: #e6f7ff;
+}
+
+.cell-wrapper {
+  position: relative;
+}
+
+.add-icon {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  font-size: 12px;
+  cursor: pointer;
+  color: #1890ff;
+}
+
+.resident-wrapper {
+  overflow: auto;
+}
+
+.resident-table {
+  border-collapse: collapse;
+  width: max-content;
+}
+
+.resident-table th,
+.resident-table td {
+  border: 1px solid #f0f0f0;
+  min-width: 100px;
+  padding: 4px;
+  vertical-align: top;
+}
+
+.resident-name-col {
+  position: sticky;
+  left: 0;
+  background: #fafafa;
+  z-index: 2;
+}
+
+.resident-name {
+  background: #fafafa;
+  white-space: nowrap;
+  position: sticky;
+  left: 0;
+  z-index: 1;
+}
+</style>

--- a/jeecgboot-vue3/src/views/caresys/V20250713_1__menu_insert_CsServiceCalendar.sql
+++ b/jeecgboot-vue3/src/views/caresys/V20250713_1__menu_insert_CsServiceCalendar.sql
@@ -1,0 +1,25 @@
+-- 注意：该页面对应的前台目录为views/caresys文件夹下
+-- 如果你想更改到其他目录，请修改sql中component字段对应的值
+
+INSERT INTO sys_permission(id, parent_id, name, url, component, component_name,redirect, menu_type, perms, perms_type, sort_no, always_show, icon, is_route, is_leaf, keep_alive, hidden, hide_tab, description, status, del_flag, rule_flag, create_by, create_time, update_by, update_time, internal_or_external)
+VALUES ('2025071309321000000', NULL, 'cs_service_calendar', '/caresys/csServiceCalendar', 'caresys/CsServiceCalendar', NULL, NULL, 0, NULL, '1', 0.00, 0, NULL, 1, 0, 0, 0, 0, NULL, '1', 0, 0, 'admin', '2025-07-13 21:32:10', NULL, NULL, 0);
+
+-- 权限控制sql
+-- 新增
+INSERT INTO sys_permission(id, parent_id, name, url, component, is_route, component_name, redirect, menu_type, perms, perms_type, sort_no, always_show, icon, is_leaf, keep_alive, hidden, hide_tab, description, create_by, create_time, update_by, update_time, del_flag, rule_flag, status, internal_or_external)
+VALUES ('2025071309321000001', '2025071309321000000', '添加cs_service_calendar', NULL, NULL, 0, NULL, NULL, 2, 'caresys:cs_service_calendar:add', '1', NULL, 0, NULL, 1, 0, 0, 0, NULL, 'admin', '2025-07-13 21:32:10', NULL, NULL, 0, 0, '1', 0);
+-- 编辑
+INSERT INTO sys_permission(id, parent_id, name, url, component, is_route, component_name, redirect, menu_type, perms, perms_type, sort_no, always_show, icon, is_leaf, keep_alive, hidden, hide_tab, description, create_by, create_time, update_by, update_time, del_flag, rule_flag, status, internal_or_external)
+VALUES ('2025071309321000002', '2025071309321000000', '编辑cs_service_calendar', NULL, NULL, 0, NULL, NULL, 2, 'caresys:cs_service_calendar:edit', '1', NULL, 0, NULL, 1, 0, 0, 0, NULL, 'admin', '2025-07-13 21:32:10', NULL, NULL, 0, 0, '1', 0);
+-- 删除
+INSERT INTO sys_permission(id, parent_id, name, url, component, is_route, component_name, redirect, menu_type, perms, perms_type, sort_no, always_show, icon, is_leaf, keep_alive, hidden, hide_tab, description, create_by, create_time, update_by, update_time, del_flag, rule_flag, status, internal_or_external)
+VALUES ('2025071309321000003', '2025071309321000000', '删除cs_service_calendar', NULL, NULL, 0, NULL, NULL, 2, 'caresys:cs_service_calendar:delete', '1', NULL, 0, NULL, 1, 0, 0, 0, NULL, 'admin', '2025-07-13 21:32:10', NULL, NULL, 0, 0, '1', 0);
+-- 批量删除
+INSERT INTO sys_permission(id, parent_id, name, url, component, is_route, component_name, redirect, menu_type, perms, perms_type, sort_no, always_show, icon, is_leaf, keep_alive, hidden, hide_tab, description, create_by, create_time, update_by, update_time, del_flag, rule_flag, status, internal_or_external)
+VALUES ('2025071309321000004', '2025071309321000000', '批量删除cs_service_calendar', NULL, NULL, 0, NULL, NULL, 2, 'caresys:cs_service_calendar:deleteBatch', '1', NULL, 0, NULL, 1, 0, 0, 0, NULL, 'admin', '2025-07-13 21:32:10', NULL, NULL, 0, 0, '1', 0);
+-- 导出excel
+INSERT INTO sys_permission(id, parent_id, name, url, component, is_route, component_name, redirect, menu_type, perms, perms_type, sort_no, always_show, icon, is_leaf, keep_alive, hidden, hide_tab, description, create_by, create_time, update_by, update_time, del_flag, rule_flag, status, internal_or_external)
+VALUES ('2025071309321000005', '2025071309321000000', '导出excel_cs_service_calendar', NULL, NULL, 0, NULL, NULL, 2, 'caresys:cs_service_calendar:exportXls', '1', NULL, 0, NULL, 1, 0, 0, 0, NULL, 'admin', '2025-07-13 21:32:10', NULL, NULL, 0, 0, '1', 0);
+-- 导入excel
+INSERT INTO sys_permission(id, parent_id, name, url, component, is_route, component_name, redirect, menu_type, perms, perms_type, sort_no, always_show, icon, is_leaf, keep_alive, hidden, hide_tab, description, create_by, create_time, update_by, update_time, del_flag, rule_flag, status, internal_or_external)
+VALUES ('2025071309321000006', '2025071309321000000', '导入excel_cs_service_calendar', NULL, NULL, 0, NULL, NULL, 2, 'caresys:cs_service_calendar:importExcel', '1', NULL, 0, NULL, 1, 0, 0, 0, NULL, 'admin', '2025-07-13 21:32:10', NULL, NULL, 0, 0, '1', 0);

--- a/jeecgboot-vue3/src/views/caresys/components/CsAnnouncementForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsAnnouncementForm.vue
@@ -25,9 +25,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="发布级别（system/company/office）" v-bind="validateInfos.level" id="CsAnnouncementForm-level" name="level">
-								<a-input v-model:value="formData.level" placeholder="请输入发布级别（system/company/office）"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="发布级别（system/company/office）" v-bind="validateInfos.level" id="CsAnnouncementForm-level" name="level">
+                                                                <a-select v-model:value="formData.level" :options="announceLevelOptions" placeholder="请选择发布级别" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="可见截止时间" v-bind="validateInfos.visibleUntil" id="CsAnnouncementForm-visibleUntil" name="visibleUntil">
@@ -49,6 +49,7 @@
   import { saveOrUpdate } from '../CsAnnouncement.api';
   import { Form } from 'ant-design-vue';
   import JFormContainer from '/@/components/Form/src/container/JFormContainer.vue';
+  import { announceLevelOptions } from '/@/enums/careSysEnum';
   const props = defineProps({
     formDisabled: { type: Boolean, default: false },
     formData: { type: Object, default: () => ({})},

--- a/jeecgboot-vue3/src/views/caresys/components/CsAttendanceForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsAttendanceForm.vue
@@ -15,9 +15,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="员工ID" v-bind="validateInfos.employeeId" id="CsAttendanceForm-employeeId" name="employeeId">
-								<a-input v-model:value="formData.employeeId" placeholder="请输入员工ID"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="员工ID" v-bind="validateInfos.employeeId" id="CsAttendanceForm-employeeId" name="employeeId">
+                                                                <JSearchSelect dict="cs_employee,name,id" v-model:value="formData.employeeId" placeholder="请选择员工" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="工作日期" v-bind="validateInfos.workDate" id="CsAttendanceForm-workDate" name="workDate">
@@ -59,6 +59,7 @@
   import { saveOrUpdate } from '../CsAttendance.api';
   import { Form } from 'ant-design-vue';
   import JFormContainer from '/@/components/Form/src/container/JFormContainer.vue';
+  import JSearchSelect from '/@/components/Form/src/jeecg/components/JSearchSelect.vue';
   const props = defineProps({
     formDisabled: { type: Boolean, default: false },
     formData: { type: Object, default: () => ({})},

--- a/jeecgboot-vue3/src/views/caresys/components/CsCalendarEventForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsCalendarEventForm.vue
@@ -20,9 +20,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="事件类型（访视/培训/检修等）" v-bind="validateInfos.eventType" id="CsCalendarEventForm-eventType" name="eventType">
-								<a-input v-model:value="formData.eventType" placeholder="请输入事件类型（访视/培训/检修等）"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="事件类型（访视/培训/检修等）" v-bind="validateInfos.eventType" id="CsCalendarEventForm-eventType" name="eventType">
+                                                                <a-select v-model:value="formData.eventType" :options="eventTypeOptions" placeholder="请选择事件类型" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="事件日期" v-bind="validateInfos.eventDate" id="CsCalendarEventForm-eventDate" name="eventDate">
@@ -49,6 +49,7 @@
   import { saveOrUpdate } from '../CsCalendarEvent.api';
   import { Form } from 'ant-design-vue';
   import JFormContainer from '/@/components/Form/src/container/JFormContainer.vue';
+  import { eventTypeOptions } from '/@/enums/careSysEnum';
   const props = defineProps({
     formDisabled: { type: Boolean, default: false },
     formData: { type: Object, default: () => ({})},

--- a/jeecgboot-vue3/src/views/caresys/components/CsCarePlanForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsCarePlanForm.vue
@@ -15,9 +15,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="关联老人" v-bind="validateInfos.residentId" id="CsCarePlanForm-residentId" name="residentId">
-								<a-input v-model:value="formData.residentId" placeholder="请输入关联老人"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="关联老人" v-bind="validateInfos.residentId" id="CsCarePlanForm-residentId" name="residentId">
+                                                                <JSearchSelect dict="cs_resident,name,id" v-model:value="formData.residentId" placeholder="请选择关联老人" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="计划开始日期" v-bind="validateInfos.planDate" id="CsCarePlanForm-planDate" name="planDate">
@@ -49,6 +49,7 @@
   import { saveOrUpdate } from '../CsCarePlan.api';
   import { Form } from 'ant-design-vue';
   import JFormContainer from '/@/components/Form/src/container/JFormContainer.vue';
+  import JSearchSelect from '/@/components/Form/src/jeecg/components/JSearchSelect.vue';
   const props = defineProps({
     formDisabled: { type: Boolean, default: false },
     formData: { type: Object, default: () => ({})},

--- a/jeecgboot-vue3/src/views/caresys/components/CsCarePlanForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsCarePlanForm.vue
@@ -25,9 +25,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="重复类型（日/周）" v-bind="validateInfos.repeatType" id="CsCarePlanForm-repeatType" name="repeatType">
-								<a-input v-model:value="formData.repeatType" placeholder="请输入重复类型（日/周）"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="重复类型（日/周）" v-bind="validateInfos.repeatType" id="CsCarePlanForm-repeatType" name="repeatType">
+                                                                <a-select v-model:value="formData.repeatType" :options="repeatTypeOptions" placeholder="请选择重复类型" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="服务内容（JSON）" v-bind="validateInfos.serviceItems" id="CsCarePlanForm-serviceItems" name="serviceItems">
@@ -50,6 +50,7 @@
   import { Form } from 'ant-design-vue';
   import JFormContainer from '/@/components/Form/src/container/JFormContainer.vue';
   import JSearchSelect from '/@/components/Form/src/jeecg/components/JSearchSelect.vue';
+  import { repeatTypeOptions } from '/@/enums/careSysEnum';
   const props = defineProps({
     formDisabled: { type: Boolean, default: false },
     formData: { type: Object, default: () => ({})},

--- a/jeecgboot-vue3/src/views/caresys/components/CsCareRecordForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsCareRecordForm.vue
@@ -15,14 +15,14 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="关联老人" v-bind="validateInfos.residentId" id="CsCareRecordForm-residentId" name="residentId">
-								<a-input v-model:value="formData.residentId" placeholder="请输入关联老人"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="关联老人" v-bind="validateInfos.residentId" id="CsCareRecordForm-residentId" name="residentId">
+                                                                <JSearchSelect dict="cs_resident,name,id" v-model:value="formData.residentId" placeholder="请选择关联老人" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="执行员工" v-bind="validateInfos.employeeId" id="CsCareRecordForm-employeeId" name="employeeId">
-								<a-input v-model:value="formData.employeeId" placeholder="请输入执行员工"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="执行员工" v-bind="validateInfos.employeeId" id="CsCareRecordForm-employeeId" name="employeeId">
+                                                                <JSearchSelect dict="cs_employee,name,id" v-model:value="formData.employeeId" placeholder="请选择执行员工" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="服务时间" v-bind="validateInfos.recordTime" id="CsCareRecordForm-recordTime" name="recordTime">
@@ -54,6 +54,7 @@
   import { saveOrUpdate } from '../CsCareRecord.api';
   import { Form } from 'ant-design-vue';
   import JFormContainer from '/@/components/Form/src/container/JFormContainer.vue';
+  import JSearchSelect from '/@/components/Form/src/jeecg/components/JSearchSelect.vue';
   const props = defineProps({
     formDisabled: { type: Boolean, default: false },
     formData: { type: Object, default: () => ({})},

--- a/jeecgboot-vue3/src/views/caresys/components/CsElderCirclePostForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsElderCirclePostForm.vue
@@ -15,9 +15,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="发布者（老人）" v-bind="validateInfos.residentId" id="CsElderCirclePostForm-residentId" name="residentId">
-								<a-input v-model:value="formData.residentId" placeholder="请输入发布者（老人）"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="发布者（老人）" v-bind="validateInfos.residentId" id="CsElderCirclePostForm-residentId" name="residentId">
+                                                                <JSearchSelect dict="cs_resident,name,id" v-model:value="formData.residentId" placeholder="请选择发布者" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="内容" v-bind="validateInfos.content" id="CsElderCirclePostForm-content" name="content">
@@ -49,6 +49,7 @@
   import { saveOrUpdate } from '../CsElderCirclePost.api';
   import { Form } from 'ant-design-vue';
   import JFormContainer from '/@/components/Form/src/container/JFormContainer.vue';
+  import JSearchSelect from '/@/components/Form/src/jeecg/components/JSearchSelect.vue';
   const props = defineProps({
     formDisabled: { type: Boolean, default: false },
     formData: { type: Object, default: () => ({})},

--- a/jeecgboot-vue3/src/views/caresys/components/CsEmployeeForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsEmployeeForm.vue
@@ -30,9 +30,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="性别" v-bind="validateInfos.gender" id="CsEmployeeForm-gender" name="gender">
-								<a-input v-model:value="formData.gender" placeholder="请输入性别"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="性别" v-bind="validateInfos.gender" id="CsEmployeeForm-gender" name="gender">
+                                                                <a-select v-model:value="formData.gender" :options="genderOptions" placeholder="请选择性别" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="出生日期" v-bind="validateInfos.birthDate" id="CsEmployeeForm-birthDate" name="birthDate">
@@ -45,9 +45,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="雇佣形态（全职/兼职等）" v-bind="validateInfos.employmentType" id="CsEmployeeForm-employmentType" name="employmentType">
-								<a-input v-model:value="formData.employmentType" placeholder="请输入雇佣形态（全职/兼职等）"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="雇佣形态（全职/兼职等）" v-bind="validateInfos.employmentType" id="CsEmployeeForm-employmentType" name="employmentType">
+                                                                <a-select v-model:value="formData.employmentType" :options="employmentTypeOptions" placeholder="请选择雇佣形态" allow-clear />
+                                                        </a-form-item>
 						</a-col>
           </a-row>
         </a-form>
@@ -65,6 +65,7 @@
   import { Form } from 'ant-design-vue';
   import JFormContainer from '/@/components/Form/src/container/JFormContainer.vue';
   import JSearchSelect from '/@/components/Form/src/jeecg/components/JSearchSelect.vue';
+  import { genderOptions, employmentTypeOptions } from '/@/enums/careSysEnum';
   const props = defineProps({
     formDisabled: { type: Boolean, default: false },
     formData: { type: Object, default: () => ({})},

--- a/jeecgboot-vue3/src/views/caresys/components/CsEmployeeForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsEmployeeForm.vue
@@ -15,9 +15,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="系统用户ID（关联sys_user.id）" v-bind="validateInfos.userId" id="CsEmployeeForm-userId" name="userId">
-								<a-input v-model:value="formData.userId" placeholder="请输入系统用户ID（关联sys_user.id）"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="系统用户ID（关联sys_user.id）" v-bind="validateInfos.userId" id="CsEmployeeForm-userId" name="userId">
+                                                                <JSearchSelect dict="sys_user,realname,id" v-model:value="formData.userId" placeholder="请选择系统用户" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="员工编号" v-bind="validateInfos.employeeCode" id="CsEmployeeForm-employeeCode" name="employeeCode">
@@ -64,6 +64,7 @@
   import { saveOrUpdate } from '../CsEmployee.api';
   import { Form } from 'ant-design-vue';
   import JFormContainer from '/@/components/Form/src/container/JFormContainer.vue';
+  import JSearchSelect from '/@/components/Form/src/jeecg/components/JSearchSelect.vue';
   const props = defineProps({
     formDisabled: { type: Boolean, default: false },
     formData: { type: Object, default: () => ({})},

--- a/jeecgboot-vue3/src/views/caresys/components/CsFeedbackForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsFeedbackForm.vue
@@ -15,9 +15,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="来源（家属/员工）" v-bind="validateInfos.source" id="CsFeedbackForm-source" name="source">
-								<a-input v-model:value="formData.source" placeholder="请输入来源（家属/员工）"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="来源（家属/员工）" v-bind="validateInfos.source" id="CsFeedbackForm-source" name="source">
+                                                                <a-select v-model:value="formData.source" :options="feedbackSourceOptions" placeholder="请选择来源" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="关联老人或员工" v-bind="validateInfos.targetId" id="CsFeedbackForm-targetId" name="targetId">
@@ -49,6 +49,7 @@
   import { saveOrUpdate } from '../CsFeedback.api';
   import { Form } from 'ant-design-vue';
   import JFormContainer from '/@/components/Form/src/container/JFormContainer.vue';
+  import { feedbackSourceOptions } from '/@/enums/careSysEnum';
   const props = defineProps({
     formDisabled: { type: Boolean, default: false },
     formData: { type: Object, default: () => ({})},

--- a/jeecgboot-vue3/src/views/caresys/components/CsResidentForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsResidentForm.vue
@@ -20,9 +20,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="性别（M:男, F:女）" v-bind="validateInfos.gender" id="CsResidentForm-gender" name="gender">
-								<a-input v-model:value="formData.gender" placeholder="请输入性别（M:男, F:女）"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="性别（M:男, F:女）" v-bind="validateInfos.gender" id="CsResidentForm-gender" name="gender">
+                                                                <a-select v-model:value="formData.gender" :options="genderOptions" placeholder="请选择性别" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="出生日期" v-bind="validateInfos.birthDate" id="CsResidentForm-birthDate" name="birthDate">
@@ -85,9 +85,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="居住类型（独居/与家人同住/机构等）" v-bind="validateInfos.residenceType" id="CsResidentForm-residenceType" name="residenceType">
-								<a-input v-model:value="formData.residenceType" placeholder="请输入居住类型（独居/与家人同住/机构等）"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="居住类型（独居/与家人同住/机构等）" v-bind="validateInfos.residenceType" id="CsResidentForm-residenceType" name="residenceType">
+                                                                <a-select v-model:value="formData.residenceType" :options="residenceTypeOptions" placeholder="请选择居住类型" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="是否有认知症" v-bind="validateInfos.isDementia" id="CsResidentForm-isDementia" name="isDementia">
@@ -105,9 +105,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="状态（active/disabled/deceased）" v-bind="validateInfos.status" id="CsResidentForm-status" name="status">
-								<a-input v-model:value="formData.status" placeholder="请输入状态（active/disabled/deceased）"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="状态（active/disabled/deceased）" v-bind="validateInfos.status" id="CsResidentForm-status" name="status">
+                                                                <a-select v-model:value="formData.status" :options="statusOptions" placeholder="请选择状态" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="逻辑删除标识" v-bind="validateInfos.deleteFlag" id="CsResidentForm-deleteFlag" name="deleteFlag">
@@ -125,6 +125,7 @@
   import { ref, reactive, defineExpose, nextTick, defineProps, computed, onMounted } from 'vue';
   import { defHttp } from '/@/utils/http/axios';
   import { useMessage } from '/@/hooks/web/useMessage';
+  import { genderOptions, residenceTypeOptions, statusOptions } from '/@/enums/careSysEnum';
   import { getValueType } from '/@/utils';
   import { saveOrUpdate } from '../CsResident.api';
   import { Form } from 'ant-design-vue';

--- a/jeecgboot-vue3/src/views/caresys/components/CsRiskReportForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsRiskReportForm.vue
@@ -15,9 +15,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="关联老人" v-bind="validateInfos.residentId" id="CsRiskReportForm-residentId" name="residentId">
-								<a-input v-model:value="formData.residentId" placeholder="请输入关联老人"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="关联老人" v-bind="validateInfos.residentId" id="CsRiskReportForm-residentId" name="residentId">
+                                                                <JSearchSelect dict="cs_resident,name,id" v-model:value="formData.residentId" placeholder="请选择关联老人" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="报告类型（跌倒等）" v-bind="validateInfos.reportType" id="CsRiskReportForm-reportType" name="reportType">
@@ -49,6 +49,7 @@
   import { saveOrUpdate } from '../CsRiskReport.api';
   import { Form } from 'ant-design-vue';
   import JFormContainer from '/@/components/Form/src/container/JFormContainer.vue';
+  import JSearchSelect from '/@/components/Form/src/jeecg/components/JSearchSelect.vue';
   const props = defineProps({
     formDisabled: { type: Boolean, default: false },
     formData: { type: Object, default: () => ({})},

--- a/jeecgboot-vue3/src/views/caresys/components/CsRiskReportForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsRiskReportForm.vue
@@ -20,9 +20,9 @@
                                                         </a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="报告类型（跌倒等）" v-bind="validateInfos.reportType" id="CsRiskReportForm-reportType" name="reportType">
-								<a-input v-model:value="formData.reportType" placeholder="请输入报告类型（跌倒等）"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="报告类型（跌倒等）" v-bind="validateInfos.reportType" id="CsRiskReportForm-reportType" name="reportType">
+                                                                <a-select v-model:value="formData.reportType" :options="reportTypeOptions" placeholder="请选择报告类型" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="报告时间" v-bind="validateInfos.reportTime" id="CsRiskReportForm-reportTime" name="reportTime">
@@ -50,6 +50,7 @@
   import { Form } from 'ant-design-vue';
   import JFormContainer from '/@/components/Form/src/container/JFormContainer.vue';
   import JSearchSelect from '/@/components/Form/src/jeecg/components/JSearchSelect.vue';
+  import { reportTypeOptions } from '/@/enums/careSysEnum';
   const props = defineProps({
     formDisabled: { type: Boolean, default: false },
     formData: { type: Object, default: () => ({})},

--- a/jeecgboot-vue3/src/views/caresys/components/CsSalaryForm.vue
+++ b/jeecgboot-vue3/src/views/caresys/components/CsSalaryForm.vue
@@ -15,9 +15,9 @@
 							</a-form-item>
 						</a-col>
 						<a-col :span="24">
-							<a-form-item label="员工ID" v-bind="validateInfos.employeeId" id="CsSalaryForm-employeeId" name="employeeId">
-								<a-input v-model:value="formData.employeeId" placeholder="请输入员工ID"  allow-clear ></a-input>
-							</a-form-item>
+                                                        <a-form-item label="员工ID" v-bind="validateInfos.employeeId" id="CsSalaryForm-employeeId" name="employeeId">
+                                                                <JSearchSelect dict="cs_employee,name,id" v-model:value="formData.employeeId" placeholder="请选择员工" allow-clear />
+                                                        </a-form-item>
 						</a-col>
 						<a-col :span="24">
 							<a-form-item label="工资月份" v-bind="validateInfos.salaryMonth" id="CsSalaryForm-salaryMonth" name="salaryMonth">
@@ -54,6 +54,7 @@
   import { saveOrUpdate } from '../CsSalary.api';
   import { Form } from 'ant-design-vue';
   import JFormContainer from '/@/components/Form/src/container/JFormContainer.vue';
+  import JSearchSelect from '/@/components/Form/src/jeecg/components/JSearchSelect.vue';
   const props = defineProps({
     formDisabled: { type: Boolean, default: false },
     formData: { type: Object, default: () => ({})},


### PR DESCRIPTION
## Summary
- enhance service calendar with resident-based table view and per-resident add buttons

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875c1d85c5c8332be8a7bb569df4e9d